### PR TITLE
tar-changes: use "Update patches" message to match rdopkg

### DIFF
--- a/tar-changes
+++ b/tar-changes
@@ -76,7 +76,7 @@ def check_new_commits(tag, old, new):
         return format_changelog(changes_data)
     else:
         # This is not a linear change (a developer rewrote history).
-        return ['Updated patches']
+        return ['Update patches']
         # TODO: find common ancestor, and figure out what diverged.
         # Need to think more about this.
         # https://github.com/softwarefactory-project/rdopkg/issues/160


### PR DESCRIPTION
When a developer force-pushes the patches branch, rdopkg and rdopkg-tar put slightly different versions of "Update(d) patches" in the changelog.

Update `rdopkg-tar`'s message to match the string that rdopkg uses.

The purpose of this change is to enable other tools that read this `%changelog` to match the same string across both tools.

Thanks @tserlin for identifying this issue.