### PR TITLE
handle private branches in guess_osdist()

### DIFF
--- a/tar-changes
+++ b/tar-changes
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import re
 from rdopkg.utils import log
 from rdopkg.utils import specfile
 from rdopkg.utils.cmd import run
@@ -108,6 +109,17 @@ def clear_old_changes_sources():
                 f.write(line)
 
 
+def guess_osdist():
+    """
+    workaround buggy guess.osdist() in rdopkg 1.2.0
+
+    https://softwarefactory-project.io/r/18391
+    """
+    branch = guess.current_branch()
+    branch = re.sub(r'^private-[^-]+-', '', branch)
+    return guess.osdist(branch)
+
+
 def main():
     spec = specfile.Spec()
 
@@ -118,7 +130,7 @@ def main():
     branch = git.current_branch()  # "ceph-3.2-rhel-7"
     tag_style = guess.version_tag_style(version=version)  # "vX.Y.Z"
     base_tag = guess.version2tag(version, tag_style)  # "v12.2.8"
-    osdist = guess.osdist()
+    osdist = guess_osdist()
 
     # "ceph-3.2-rhel-patches"
     remote_patches_branch = guess.patches_branch(branch, pkg=name,
@@ -154,7 +166,7 @@ def main():
     rdopkg.actions.distgit.actions.update_spec(branch=branch, changes=changes)
 
     # add + upload this new tarball.
-    if guess.new_sources():
+    if guess.new_sources(_osdist=osdist):
         fedpkg = 'fedpkg'
         if osdist.startswith('RH'):
             fedpkg = 'rhpkg'

--- a/test_tar_changes.py
+++ b/test_tar_changes.py
@@ -2,6 +2,7 @@ import os
 import importlib.machinery
 import importlib.util
 import py.path
+import pytest
 
 loader = importlib.machinery.SourceFileLoader('tarchanges', 'tar-changes')
 spec = importlib.util.spec_from_loader(loader.name, loader)
@@ -23,3 +24,14 @@ def test_clear_old_changes_sources(tmpdir, monkeypatch):
     sources = tmpdir.join('sources')
     expected = '3a393d427d5b16c33cf24da91244cc7a  ceph-12.2.8.tar.gz\n'
     sources.read() == expected
+
+
+@pytest.mark.parametrize("test_input,expected", [
+    ('master', 'RDO'),
+    ('ceph-5.0-rhel-8', 'RHCEPH'),
+    ('private-kdreyer-ceph-5.0-rhel-8', 'RHCEPH'),
+])
+def test_guess_osdist(monkeypatch, test_input, expected):
+    monkeypatch.setattr(tarchanges.guess, 'current_branch', lambda: test_input)
+    result = tarchanges.guess_osdist()
+    assert result == expected


### PR DESCRIPTION
The next release of rdopkg after 1.2.0 will properly handle private- branches, but for now we need to wrap this method and do the regex substitution ourselves.

Fixes: #4